### PR TITLE
refactor(input): refactor, create test, and document using storybook. [CH-08]

### DIFF
--- a/src/components/input/__tests__/input.mock.tsx
+++ b/src/components/input/__tests__/input.mock.tsx
@@ -1,0 +1,19 @@
+import { UseFormRegister } from "react-hook-form";
+import { IInputProps } from "../input.interface";
+
+export const textInputMock: IInputProps = {
+  id: "name",
+  label: "Name",
+  name: "name",
+  register: (() => {}) as unknown as UseFormRegister<any>,
+  onClick: undefined,
+};
+
+export const passwordInputMock: IInputProps = {
+  id: "password",
+  label: "Password",
+  name: "password",
+  register: (() => {}) as unknown as UseFormRegister<any>,
+  isVisible: false,
+  type: "password",
+};

--- a/src/components/input/__tests__/input.spec.tsx
+++ b/src/components/input/__tests__/input.spec.tsx
@@ -1,0 +1,108 @@
+/* eslint-disable no-undef */
+import { act, fireEvent, render } from "@testing-library/react";
+
+import { Input } from "../input";
+import { passwordInputMock, textInputMock } from "./input.mock";
+
+describe("Input Component", () => {
+  const mockRegister = jest.fn();
+  test("Input should render with the right properties for text", () => {
+    const { container, getByText } = render(
+      <Input {...textInputMock} register={mockRegister} />
+    );
+
+    const plantCard = container.querySelector(
+      '[data-testid="input-container"]'
+    );
+    expect(plantCard).toBeInTheDocument();
+
+    const inputElement = container.querySelector(
+      '[data-testid="input-component"]'
+    ) as HTMLInputElement;
+    expect(inputElement).toBeInTheDocument();
+
+    expect(inputElement.type).toBe("text");
+    expect(inputElement.id).toBe("name");
+
+    const label = getByText(textInputMock.label);
+    expect(label).toBeInTheDocument();
+
+    const passwordVisibleButton = plantCard?.querySelector(".eye-icon");
+    expect(passwordVisibleButton).not.toBeInTheDocument();
+  });
+
+  test("Input should render with the right properties for password", () => {
+    const mockEyeClick = jest.fn();
+    const { container } = render(
+      <Input
+        {...passwordInputMock}
+        register={mockRegister}
+        onClick={mockEyeClick}
+      />
+    );
+
+    const plantCard = container.querySelector(
+      '[data-testid="input-container"]'
+    );
+    expect(plantCard).toBeInTheDocument();
+
+    const inputElement = container.querySelector(
+      '[data-testid="input-component"]'
+    ) as HTMLInputElement;
+    expect(inputElement).toBeInTheDocument();
+
+    expect(inputElement.type).toBe("password");
+    expect(inputElement.id).toBe("password");
+
+    const passwordVisibleButton = plantCard?.querySelector(".eye-icon");
+    expect(passwordVisibleButton).toBeInTheDocument();
+
+    const passwordIcon = passwordVisibleButton?.querySelector(
+      '[data-testid="eye-visible"]'
+    );
+    expect(passwordIcon).toBeInTheDocument();
+  });
+
+  test("Input should show the right password icon", () => {
+    const mockEyeClick = jest.fn();
+    const { container } = render(
+      <Input
+        {...passwordInputMock}
+        register={mockRegister}
+        onClick={mockEyeClick}
+        isVisible={true}
+      />
+    );
+
+    const passwordIcon = container.querySelector(
+      '[data-testid="eye-invisible"]'
+    );
+    expect(passwordIcon).toBeInTheDocument();
+  });
+
+  test("Input should trigger handle if  with the right properties for password", () => {
+    const mockEyeClick = jest.fn();
+    const { container } = render(
+      <Input
+        {...passwordInputMock}
+        register={mockRegister}
+        onClick={mockEyeClick}
+      />
+    );
+
+    const plantCard = container.querySelector(
+      '[data-testid="input-container"]'
+    );
+    expect(plantCard).toBeInTheDocument();
+
+    const passwordVisibleButton = plantCard?.querySelector(".eye-icon");
+
+    expect(passwordVisibleButton).toBeInTheDocument();
+    if (passwordVisibleButton) {
+      act(() => {
+        fireEvent.click(passwordVisibleButton);
+      });
+      expect(mockEyeClick).toBeCalledTimes(1);
+    }
+  });
+});

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -1,2 +1,2 @@
-export { InputContainer } from "./input";
-export type { IInputProps, IInputContainerProps } from "./input.interface";
+export { Input } from "./input";
+export type { IInputProps } from "./input.interface";

--- a/src/components/input/input.interface.ts
+++ b/src/components/input/input.interface.ts
@@ -1,12 +1,12 @@
-import { InputHTMLAttributes, ReactElement } from "react";
+import { HTMLInputTypeAttribute } from "react";
+import { UseFormRegister } from "react-hook-form";
 
-export interface IInputProps extends InputHTMLAttributes<HTMLInputElement> {
-  label: string;
-}
-export interface IInputContainerProps {
-  children: ReactElement;
+export interface IInputProps {
   id: string;
   label: string;
+  name: string;
+  register: UseFormRegister<any>;
   isVisible?: boolean;
   onClick?: () => void;
+  type?: HTMLInputTypeAttribute;
 }

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -1,25 +1,33 @@
 import { FC } from "react";
-import { IInputContainerProps } from "./input.interface";
+import { IInputProps } from "./input.interface";
 import { StylesWrapper } from "./input.styles";
 import { AiOutlineEye, AiOutlineEyeInvisible } from "react-icons/ai";
 
-export const InputContainer: FC<IInputContainerProps> = ({
-  children,
+export const Input: FC<IInputProps> = ({
   id,
   label,
+  name,
+  register,
   isVisible,
   onClick,
+  type = "text",
 }) => {
   return (
-    <StylesWrapper className="input-wrapper">
-      {children}
+    <StylesWrapper className="input-wrapper" data-testid="input-container">
+      <input
+        type={type}
+        id={id}
+        placeholder=" "
+        {...register(name)}
+        data-testid="input-component"
+      />
       <label htmlFor={id}>{label}</label>
       {onClick ? (
         <button onClick={onClick} type="button" className="eye-icon">
           {isVisible ? (
-            <AiOutlineEyeInvisible size={20} />
+            <AiOutlineEyeInvisible size={20} data-testid="eye-invisible" />
           ) : (
-            <AiOutlineEye size={20} />
+            <AiOutlineEye size={20} data-testid="eye-visible" />
           )}
         </button>
       ) : null}

--- a/src/components/login-modal/login-modal.tsx
+++ b/src/components/login-modal/login-modal.tsx
@@ -5,12 +5,12 @@ import {
   FormType,
 } from "./login-modal.interface";
 import { Modal } from "@/components/modal";
-import { Button } from "../button";
+import { Button } from "@/components/button";
 import { StylesWrapper } from "./login-modal.styles";
 import { FcGoogle } from "react-icons/fc";
 import { useForm } from "react-hook-form";
 import { useRouter } from "next/router";
-import { InputContainer } from "../input";
+import { Input } from "@/components/input";
 import {
   EMAIL,
   GOOGLE_SIGN_IN,
@@ -67,27 +67,16 @@ export const LoginModal: FC<ILoginModalProps> = ({ open = true, onClose }) => {
           <h2>{LOGIN_HEADER}</h2>
         </div>
         <form onSubmit={onSubmit}>
-          <InputContainer id="email" label={EMAIL}>
-            <input
-              type="text"
-              id="email"
-              placeholder=" "
-              {...register("email")}
-            />
-          </InputContainer>
-          <InputContainer
+          <Input id="email" label={EMAIL} name="email" register={register} />
+          <Input
             id="password"
             label={PASSWORD}
+            name="password"
+            register={register}
             onClick={onPasswordClicked}
             isVisible={isVisible}
-          >
-            <input
-              type={isVisible ? "text" : "password"}
-              id="password"
-              placeholder=" "
-              {...register("password")}
-            />
-          </InputContainer>
+            type={isVisible ? "text" : "password"}
+          />
           {errorVisible && (
             <p className="error-message">email or password is invalid</p>
           )}

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -1,6 +1,6 @@
 import { TransitionImage } from "@/components/image";
 import { Button } from "@/components/button";
-import { InputContainer } from "@/components/input";
+import { Input } from "@/components/input";
 import { RegisterLayout } from "@/components/layouts/register";
 import { getRegisterImage } from "@/sanity/get-register-image";
 import { useForm } from "react-hook-form";
@@ -69,48 +69,26 @@ export default function Register({ image }: ImageType) {
           {REGISTER_HEADER} {CACTI}
         </h1>
         <form className="register-form" onSubmit={onSubmit}>
-          <InputContainer id="name" label={NAME}>
-            <input
-              id="name"
-              type="text"
-              placeholder=" "
-              {...register("name")}
-            />
-          </InputContainer>
-          <InputContainer id="email" label={EMAIL}>
-            <input
-              id="email"
-              type="text"
-              placeholder=" "
-              {...register("email")}
-            />
-          </InputContainer>
-          <InputContainer
+          <Input id="name" label={NAME} name="name" register={register} />
+          <Input id="email" label={EMAIL} name="email" register={register} />
+          <Input
             id="password"
             label={PASSWORD}
+            name="password"
+            register={register}
             isVisible={isPasswordVisible}
             onClick={onPasswordClicked}
-          >
-            <input
-              id="password"
-              type={isPasswordVisible ? "text" : "password"}
-              placeholder=" "
-              {...register("password")}
-            />
-          </InputContainer>
-          <InputContainer
-            id="passwordConf"
+            type={isPasswordVisible ? "text" : "password"}
+          />
+          <Input
+            id="passwordConfirmation"
             label={PASSWORD_CONFIRMATION}
+            name="passwordConfirmation"
+            register={register}
             isVisible={isConfirmationVisible}
             onClick={onConfirmationClicked}
-          >
-            <input
-              id="passwordConf"
-              type={isConfirmationVisible ? "text" : "password"}
-              placeholder=" "
-              {...register("passwordConfirmation")}
-            />
-          </InputContainer>
+            type={isConfirmationVisible ? "text" : "password"}
+          />
           {errorVisible && <p className="error-message">{errorMessage}</p>}
           <Button
             isLoading={isLoading}

--- a/src/stories/input.stories.tsx
+++ b/src/stories/input.stories.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable no-undef */
+import { Input } from "@/components/input";
+import {
+  passwordInputMock,
+  textInputMock,
+} from "@/components/input/__tests__/input.mock";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Components/Input",
+  component: Input,
+  parameters: passwordInputMock,
+  decorators: [
+    (Story) => (
+      <div style={{ width: "30rem" }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TextInput: Story = {
+  args: textInputMock,
+};
+export const PasswordInput: Story = {
+  args: passwordInputMock,
+};

--- a/src/stories/plant-card.stories.tsx
+++ b/src/stories/plant-card.stories.tsx
@@ -1,16 +1,18 @@
-import { PlantCard } from "@/components/refactor-card";
-import { plantCardMock } from "@/components/refactor-card/__tests__/plant-card.mock";
+import { PlantCard } from "@/components/plant-card";
+import { plantCardMock } from "@/components/plant-card/__tests__/plant-card.mock";
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
   title: "Components/PlantCard",
   component: PlantCard,
   parameters: plantCardMock,
-  decorators: [(Story) => (
-    <div style={{ width: '30rem'}}>
-      <Story />
-    </div>
-  )]
+  decorators: [
+    (Story) => (
+      <div style={{ width: "30rem" }}>
+        <Story />
+      </div>
+    ),
+  ],
 } satisfies Meta<typeof PlantCard>;
 
 export default meta;


### PR DESCRIPTION
### PR SUMMARY:
**WHAT**
Refactor the input component

**WHY**
The file structure needed some cleaning, the input element should be inside the component itself instead of in the parent

**HOW**
- Refactor custom input component
- Create testing for input component
- Create documentation for the input component using Storybook
- Update login modal and register page to use the new input component

**This PR Consist of:**
[ ] New dependencies
[ ] Version update in dependencies
[ ] Changes in .env file

**Documentation:**
No changes in visual

**Ticket Link:** https://www.notion.so/CH-08-Refactor-Input-Component-367720ea1062433ca8fb998201ac8645?pvs=4